### PR TITLE
Update pageUrl -> page_url

### DIFF
--- a/crisp/partials/pagination.hbs
+++ b/crisp/partials/pagination.hbs
@@ -1,5 +1,5 @@
 <nav class="pagination" role="pagination">
-    {{#if prev}}<a class="newer-posts" href="{{pageUrl prev}}">&larr; Newer</a> <span class="separator">|</span> {{/if}}
+    {{#if prev}}<a class="newer-posts" href="{{page_url prev}}">&larr; Newer</a> <span class="separator">|</span> {{/if}}
     <span class="page-number">Page {{page}} of {{pages}}</span>
-    {{#if next}} <span class="separator">|</span> <a class="older-posts" href="{{pageUrl next}}">Older &rarr;</a>{{/if}}
+    {{#if next}} <span class="separator">|</span> <a class="older-posts" href="{{page_url next}}">Older &rarr;</a>{{/if}}
 </nav>


### PR DESCRIPTION
Ghost 0.4.2 deprecated the pageUrl helper and renamed it to page_url.
