### PR TITLE
Fix post.hbs

### DIFF
--- a/crisp/post.hbs
+++ b/crisp/post.hbs
@@ -9,7 +9,7 @@
 	<div id="disqus_thread"></div>
 	<script type="text/javascript">
 	    var disqus_shortname = 'example'; // required: replace example with your shortname
-	    var disqus_identifier = '{{post.id}}';
+	    var disqus_identifier = '{{id}}';
 	    (function() {
 	        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
 	        dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';


### PR DESCRIPTION
`post.id` is not defined in post.hbs - all attributes of the post are directly accessible. For details check out `{{log this}}` which will show you all available values.
