### PR TITLE
Support blog cover image

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A minimalist, responsive, and open-source theme for [Ghost](http://ghost.org) by
 * Add code for Google Analytics in **default.hbs** after `{{ghost_foot}}`
 * Replace the Disqus universal embed code in **partials/comments.hbs**, or delete the #comments div to remove comments altogether
 * Remove irrelevant social sharing services in **partials/share.hbs**, or change the colors of social sharing services in **assets/styles/rrssb.css**
-* Change your blog logo to change the favicon and the picture in the sidebar (the blog cover is not used)
+* Change your blog logo to change the favicon and the picture in the sidebar
 
 ### Editing Follow Buttons
 

--- a/assets/styles/crisp.css
+++ b/assets/styles/crisp.css
@@ -26,6 +26,8 @@ header {
 	left: 0;
 	height:100%;
 	width:13.5em;
+	background-repeat: no-repeat;
+	background-size: cover;
 }
 #content {
 	display: block;

--- a/default.hbs
+++ b/default.hbs
@@ -24,7 +24,7 @@
 	    {{ghost_head}}
 	</head>
 	<body class="{{body_class}}">
-		<header id="header">
+		<header id="header" {{#if @blog.cover_image}}style="background-image: url('{{@blog.cover_image}}')"{{/if}}>
 			{{#if @blog.logo}}<a id="logo" href="{{@blog.url}}"><img src="{{@blog.logo}}" alt="{{@blog.title}}" /></a>{{/if}}
 			<h1><a href="{{@blog.url}}">{{@blog.title}}</a></h1>
 			<p>{{@blog.description}}</p>


### PR DESCRIPTION
This PR applies the cover image set in Settings > General as the background image of the sidebar (`#header`).