### PR TITLE
Make follow buttons open in new window / tab.

### DIFF
--- a/partials/follow.hbs
+++ b/partials/follow.hbs
@@ -1,18 +1,18 @@
 <div id="follow-icons">
-	<a href="{{facebook_url}}"><i class="fa fa-facebook-square fa-2x"></i></a>
-	<a href="{{twitter_url}}"><i class="fa fa-twitter-square fa-2x"></i></a>
-	<a href="http://linkedin.com/in/username"><i class="fa fa-linkedin-square fa-2x"></i></a>
-	<a href="mailto:you@example.com"><i class="fa fa-envelope-square fa-2x"></i></a>
-	<a href="{{@blog.url}}/rss"><i class="fa fa-rss-square fa-2x"></i></a> 
+	<a href="{{facebook_url}}" target="_blank"><i class="fa fa-facebook-square fa-2x"></i></a>
+	<a href="{{twitter_url}}" target="_blank"><i class="fa fa-twitter-square fa-2x"></i></a>
+	<a href="http://linkedin.com/in/username" target="_blank"><i class="fa fa-linkedin-square fa-2x"></i></a>
+	<a href="mailto:you@example.com" target="_blank"><i class="fa fa-envelope-square fa-2x"></i></a>
+	<a href="{{@blog.url}}/rss" target="_blank"><i class="fa fa-rss-square fa-2x"></i></a> 
 </div>                                                                  
 
 <!--
-<a href="http://github.com/username"><i class="fa fa-github-square fa-2x"></i></a>
-<a href="http://plus.google.com/+username"><i class="fa fa-google-plus-square fa-2x"></i></a>
-<a href="http://instagram.com/username"><i class="fa fa-instagram fa-2x"></i></a>
-<a href="http://vimeo.com/username"><i class="fa fa-vimeo-square fa-2x"></i></a>
-<a href="http://youtube.com/username"><i class="fa fa-youtube-square fa-2x"></i></a>
-<a href="http://flickr.com/username"><i class="fa fa-flickr fa-2x"></i></a>
-<a href="http://pinterest.com/username"><i class="fa fa-pinterest-square fa-2x"></i></a>
-<a href="http://username.tumblr.com"><i class="fa fa-tumblr-square fa-2x"></i></a>
+<a href="http://github.com/username" target="_blank"><i class="fa fa-github-square fa-2x"></i></a>
+<a href="http://plus.google.com/+username" target="_blank"><i class="fa fa-google-plus-square fa-2x"></i></a>
+<a href="http://instagram.com/username" target="_blank"><i class="fa fa-instagram fa-2x"></i></a>
+<a href="http://vimeo.com/username" target="_blank"><i class="fa fa-vimeo-square fa-2x"></i></a>
+<a href="http://youtube.com/username" target="_blank"><i class="fa fa-youtube-square fa-2x"></i></a>
+<a href="http://flickr.com/username" target="_blank"><i class="fa fa-flickr fa-2x"></i></a>
+<a href="http://pinterest.com/username" target="_blank"><i class="fa fa-pinterest-square fa-2x"></i></a>
+<a href="http://username.tumblr.com" target="_blank"><i class="fa fa-tumblr-square fa-2x"></i></a>
 -->


### PR DESCRIPTION
The follow buttons in the theme currently open links (FB, LinkedIn, Twitter etc) in the same tab, which is rather unexpected. This PR changes the buttons to open new window / tab instead.