### PR TITLE
minor changes for ghost v4 compatibility

### DIFF
--- a/assets/styles/crisp.css
+++ b/assets/styles/crisp.css
@@ -275,3 +275,143 @@ footer a:hover {
 		margin-left: 2em; 
 	}
 }
+
+/* ghost compatibility */
+
+.kg-width-wide {
+  position: relative;
+  width: 85vw;
+  min-width: 100%;
+  margin: auto calc(50% - 50vw);
+  transform: translateX(calc(50vw - 50%));
+}
+
+.kg-width-full {
+  position: relative;
+  width: 100vw;
+  left: 50%;
+  right: 50%;
+  margin-left: -50vw;
+  margin-right: -50vw;
+}
+
+.kg-bookmark-card {
+    width: 100%;
+    position: relative;
+}
+
+.kg-bookmark-container {
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: row-reverse;
+    color: currentColor;
+    font-family: inherit;
+    text-decoration: none;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.kg-bookmark-container:hover {
+    text-decoration: none;
+}
+
+.kg-bookmark-content {
+    flex-basis: 0;
+    flex-grow: 999;
+    padding: 20px;
+    order: 1;
+}
+
+.kg-bookmark-title {
+    font-weight: 600;
+}
+
+.kg-bookmark-metadata,
+.kg-bookmark-description {
+    margin-top: .5em;
+}
+
+.kg-bookmark-metadata {
+    align-items: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.kg-bookmark-description {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+}
+
+.kg-bookmark-icon {
+    display: inline-block;
+    width: 1em;
+    height: 1em;
+    vertical-align: text-bottom;
+    margin-right: .5em;
+    margin-bottom: .05em;
+}
+
+.kg-bookmark-thumbnail {
+    display: flex;
+    flex-basis: 24rem;
+    flex-grow: 1;
+}
+
+.kg-bookmark-thumbnail img {
+    max-width: 100%;
+    height: auto;
+    vertical-align: bottom;
+    object-fit: cover;
+}
+
+.kg-bookmark-author {
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+}
+
+.kg-bookmark-publisher::before {
+    content: "•";
+    margin: 0 .5em;
+}
+
+.kg-image-card,
+.kg-gallery-card {
+    margin: 0 0 1.5em;
+}
+
+.kg-image-card figcaption,
+.kg-gallery-card figcaption {
+    margin: -1.0em 0 1.5em;
+}
+
+.kg-gallery-container {
+    display: flex;
+    flex-direction: column;
+    margin: 1.5em auto;
+    max-width: 1040px;
+    width: 100vw;
+}
+
+.kg-gallery-row {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+}
+
+.kg-gallery-image img {
+    display: block;
+    margin: 0;
+    width: 100%;
+    height: 100%;
+}
+
+.kg-gallery-row:not(:first-of-type) {
+    margin: 0.75em 0 0 0;
+}
+
+.kg-gallery-image:not(:first-of-type) {
+    margin: 0 0 0 0.75em;
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "description" : "A minimalist, responsive, and open-source theme for Ghost",
     "version"     : "1.0.0",
     "engines": {
-        "ghost-api": "v3"
+        "ghost-api": "v4"
     },
     "license": "MIT",
     "screenshots": {

--- a/page.hbs
+++ b/page.hbs
@@ -1,6 +1,6 @@
 {{!< default}}
 {{#post}}
-<article id="{{id}}" class="{{post_class}}">
+<article id="{{comment_id}}" class="{{post_class}}">
 	<h1 class="post-title">{{title}}</h1>
 	{{content}}
 </article>

--- a/partials/postlist.hbs
+++ b/partials/postlist.hbs
@@ -1,5 +1,5 @@
 {{#foreach posts}}
-<section id="{{id}}" class="{{post_class}}">
+<section id="{{comment_id}}" class="{{post_class}}">
 	<h3 class="post-title"><a href="{{url}}">{{title}}</a><span class="separator"> &middot; </span>{{date published_at format='MMMM D, YYYY'}}<span class="taglist">{{tags separator=" " prefix=" &middot; "}}</span>{{#if featured}}<span class="separator"> &middot; </span><i class="fa fa-star-o feature-star"></i>{{/if}}</h3>
 </section>
 {{/foreach}}

--- a/post.hbs
+++ b/post.hbs
@@ -1,6 +1,6 @@
 {{!< default}}
 {{#post}}
-<article id="{{id}}" class="{{post_class}}">
+<article id="{{comment_id}}" class="{{post_class}}">
 	<div class="post-stamp">{{date published_at format='MMMM D, YYYY'}}<span class="taglist">{{tags separator=" " prefix=" &middot; "}}</span>{{#if featured}}<span class="separator"> &middot; </span><i class="fa fa-star-o feature-star"></i>{{/if}}</div>
 	<h1 class="post-title">{{title}}</h1>
 	{{content}}


### PR DESCRIPTION
I've added ghost's koenig editor requirements, changed api version.

id = comment_id change is gscan's recommendation.

Theme is now fully compatible with ghost v4, tested in local development envoriment.